### PR TITLE
Change RFC to MCIP

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,6 +1,6 @@
 - Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
-- MCIP PR: [mobilecoinfoundation/MCIPs#0000](https://github.com/mobilecoinfoundation/MCIPs/pull/0000)
+- MCIP PR: [mobilecoinfoundation/mcips#0000](https://github.com/mobilecoinfoundation/mcips/pull/0000)
 - MobileCoin Epic: JIRA-1234
 
 # Summary

--- a/0000-template.md
+++ b/0000-template.md
@@ -1,6 +1,6 @@
 - Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
-- RFC PR: [mobilecoinfoundation/rfcs#0000](https://github.com/mobilecoinfoundation/rfcs/pull/0000)
+- MCIP PR: [mobilecoinfoundation/MCIPs#0000](https://github.com/mobilecoinfoundation/MCIPs/pull/0000)
 - MobileCoin Epic: JIRA-1234
 
 # Summary
@@ -24,12 +24,12 @@ Explain the proposal as if it was already included in the system and you were te
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 - If applicable, describe the differences between teaching this to existing users and new users.
 
-For implementation-oriented RFCs (e.g. for ledger formats), this section should focus on how other contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+For implementation-oriented MCIPs (e.g. for ledger formats), this section should focus on how other contributors should think about the change, and give examples of its concrete impact. For policy MCIPs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
+This is the technical portion of the MCIP. Explain the design in sufficient detail that:
 
 - Its interaction with other features is clear.
 - It is reasonably clear how the feature would be implemented.
@@ -60,18 +60,18 @@ A few examples of what this can include are:
 - For other teams: What lessons can we learn from what other communities have done here?
 - Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
 
-This section is intended to encourage you as an author to think about the lessons from other systems, provide readers of your RFC with a fuller picture.
+This section is intended to encourage you as an author to think about the lessons from other systems, provide readers of your MCIP with a fuller picture.
 If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other systems.
 
-Note that while precedent set by other systems is some motivation, it does not on its own motivate an RFC.
+Note that while precedent set by other systems is some motivation, it does not on its own motivate an MCIP.
 Please also take into consideration that MobileCoin sometimes intentionally diverges from common cryptocurrency features.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the MCIP process before this gets merged?
 - What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+- What related issues do you consider out of scope for this MCIP that could be addressed in the future independently of the solution that comes out of this MCIP?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
@@ -83,13 +83,13 @@ with aspects of the project in your proposal. Also consider how this all
 fits into the roadmap for the project and of the relevant team.
 
 This is also a good place to "dump ideas", if they are out of scope for the
-RFC you are writing but otherwise related.
+MCIP you are writing but otherwise related.
 
 If you have tried and cannot think of any future possibilities,
 you may simply state that you cannot think of anything.
 
 Note that having something written down in the future-possibilities section
-is not a reason to accept the current or a future RFC; such notes should be
-in the section on motivation or rationale in this or subsequent RFCs.
+is not a reason to accept the current or a future MCIP; such notes should be
+in the section on motivation or rationale in this or subsequent MCIPs.
 The section merely provides additional information.
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ merged into the MCIP repository as a markdown file. At that point the MCIP is
     the FCP is canceled, and the MCIP goes back into development mode.
 
 ## The MCIP life-cycle
-[The MCIP life-cycle]: #the-MCIP-life-cycle
+[The MCIP life-cycle]: #the-mcip-life-cycle
 
 Once an MCIP becomes "active" then authors may implement it and submit the
 feature as a pull request to the relevant repo. Being "active" is not a rubber
@@ -178,7 +178,7 @@ as a "very minor change" is up to the team to decide; check
 
 
 ## Reviewing MCIPs
-[Reviewing MCIPs]: #reviewing-MCIPs
+[Reviewing MCIPs]: #reviewing-mcips
 
 While the MCIP pull request is up, the team may schedule meetings with the
 author and/or relevant stakeholders to discuss the issues in greater detail,
@@ -194,7 +194,7 @@ rationale for the decision.
 
 
 ## Implementing an MCIP
-[Implementing an MCIP]: #implementing-an-MCIP
+[Implementing an MCIP]: #implementing-an-mcip
 
 Some accepted MCIPs represent vital features that need to be implemented right
 away. Other accepted MCIPs can represent features that can wait until some
@@ -213,7 +213,7 @@ cannot determine if someone else is already working on it, feel free to ask
 
 
 ## MCIP Postponement
-[MCIP Postponement]: #MCIP-postponement
+[MCIP Postponement]: #mcip-postponement
 
 Some MCIP pull requests are tagged with the "postponed" label when they are
 closed (as part of the rejection process). An MCIP closed with "postponed" is
@@ -252,4 +252,4 @@ This repository is licensed as:
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed as above, without any additional terms or conditions.
 
 
-[MCIP repository]: https://github.com/mobilecoinfoundation/MCIPs
+[MCIP repository]: https://github.com/mobilecoinfoundation/mcips

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MobileCoin RFCs
+# MobileCoin Improvement Proposals (MCIPs)
 
-[MobileCoin RFCs]: #mc-rfcs
+[MobileCoin Improvement Proposals]: #mcips
 
 Many changes, including bug fixes and documentation improvements can be
 implemented and reviewed via the normal GitHub pull request workflow.
@@ -9,24 +9,24 @@ Some changes though are "substantial", and we ask that these be put through a
 bit of a design process and produce a consensus among the MobileCoin community and
 the teams.
 
-The "RFC" (request for comments) process is intended to provide a consistent
+The "MCIP" (MobileCoin Improvement Proposal) process is intended to provide a consistent
 and controlled path for new features to enter the ecosystem, so that all
-stakeholders can be confident about the direction the currency is evolving in.
+stakeholders can be confident about the direction the protocol is evolving in.
 
 
 ## Table of Contents
 [Table of Contents]: #table-of-contents
 
-  - [Opening](#mc-rfcs)
+  - [Opening](#mcips)
   - [Table of Contents]
   - [When you need to follow this process]
   - [Team-specific guidelines]
-  - [Before creating an RFC]
+  - [Before creating an MCIP]
   - [What the process is]
-  - [The RFC life-cycle]
-  - [Reviewing RFCs]
-  - [Implementing an RFC]
-  - [RFC Postponement]
+  - [The MCIP life-cycle]
+  - [Reviewing MCIPs]
+  - [Implementing an MCIP]
+  - [MCIP Postponement]
   - [Help this is all too informal!]
   - [License]
   - [Contributions]
@@ -35,8 +35,8 @@ stakeholders can be confident about the direction the currency is evolving in.
 ## When you need to follow this process
 [When you need to follow this process]: #when-you-need-to-follow-this-process
 
-You need to follow this process if you intend to make "substantial" changes to
-MobileCoin Foundation codebase, or the RFC process itself. What constitutes a
+You need to follow this process if you intend to make "substantial" changes to the
+MobileCoin Foundation codebase, or the MCIP process itself. What constitutes a
 "substantial" change is evolving based on community norms and varies depending
 on what part of the ecosystem you are proposing to change, but may include the
 following.
@@ -45,7 +45,7 @@ following.
   - Removing features.
   - Changes to the interface between the clients and servers.
 
-Some changes do not require an RFC:
+Some changes do not require an MCIP:
 
   - Rephrasing, reorganizing, refactoring, or otherwise "changing shape does
     not change meaning".
@@ -56,167 +56,167 @@ Some changes do not require an RFC:
     invisible to users-of-mobilecoin.
 
 If you submit a pull request to implement a new feature without going through
-the RFC process, it may be closed with a polite request to submit an RFC first.
+the MCIP process, it may be closed with a polite request to submit an MCIP first.
 
 
 ### Team specific guidelines
 [Team-specific guidelines]: #team-specific-guidelines
 
-For more details on when an RFC is required for the following areas, please see
+For more details on when an MCIP is required for the following areas, please see
 the foundation's team-specific guidelines for:
 
   - [consensus](consensus.md),
   - [fog](fog.md),
 
 
-## Before creating an RFC
-[Before creating an RFC]: #before-creating-an-rfc
+## Before creating an MCIP
+[Before creating an MCIP]: #before-creating-an-mcip
 
-A hastily-proposed RFC can hurt its chances of acceptance. Low quality
+A hastily-proposed MCIP can hurt its chances of acceptance. Low quality
 proposals, proposals for previously-rejected features, or those that don't fit
 into the near-term roadmap, may be quickly rejected, which can be demotivating
-for the unprepared contributor. Laying some groundwork ahead of the RFC can
+for the unprepared contributor. Laying some groundwork ahead of the MCIP can
 make the process smoother.
 
-Although there is no single way to prepare for submitting an RFC, it is
+Although there is no single way to prepare for submitting an MCIP, it is
 generally a good idea to pursue feedback from other project developers
-beforehand, to ascertain that the RFC may be desirable; having a consistent
+beforehand, to ascertain that the MCIP may be desirable; having a consistent
 impact on the project requires concerted effort toward consensus-building.
 
 As a rule of thumb, receiving encouraging feedback from long-standing project
 developers, and particularly members of the relevant team is a good
-indication that the RFC is worth pursuing.
+indication that the MCIP is worth pursuing.
 
 
 ## What the process is
 [What the process is]: #what-the-process-is
 
-In short, to get a major feature added to MobileCoin, one must first get the RFC
-merged into the RFC repository as a markdown file. At that point the RFC is
+In short, to get a major feature added to MobileCoin, one must first get the MCIP
+merged into the MCIP repository as a markdown file. At that point the MCIP is
 "active" and may be implemented with the goal of eventual inclusion into MobileCoin.
 
-  - Fork the RFC repo [RFC repository]
+  - Fork the MCIP repo [MCIP repository]
   - Copy `0000-template.md` to `text/0000-my-feature.md` (where "my-feature" is
-    descriptive). Don't assign an RFC number yet; This is going to be the PR
-    number and we'll rename the file accordingly if the RFC is accepted.
-  - Fill in the RFC. Put care into the details: RFCs that do not present
+    descriptive). Don't assign an MCIP number yet; This is going to be the PR
+    number and we'll rename the file accordingly if the MCIP is accepted.
+  - Fill in the MCIP. Put care into the details: MCIPs that do not present
     convincing motivation, demonstrate lack of understanding of the design's
     impact, or are disingenuous about the drawbacks or alternatives tend to
     be poorly-received.
-  - Submit a pull request. As a pull request the RFC will receive design
+  - Submit a pull request. As a pull request the MCIP will receive design
     feedback from the larger community, and the author should be prepared to
     revise it in response.
-  - Now that your RFC has an open pull request, use the issue number of the PR
+  - Now that your MCIP has an open pull request, use the issue number of the PR
     to update your `0000-` prefix to that number.
   - Each pull request will be labeled with the most relevant team, which
     will lead to its being triaged by that team in a future meeting and assigned
     to a member of the team.
-  - Build consensus and integrate feedback. RFCs that have broad support are
+  - Build consensus and integrate feedback. MCIPs that have broad support are
     much more likely to make progress than those that don't receive any
-    comments. Feel free to reach out to the RFC assignee in particular to get
+    comments. Feel free to reach out to the MCIP assignee in particular to get
     help identifying stakeholders and obstacles.
-  - The team will discuss the RFC pull request, as much as possible in the
+  - The team will discuss the MCIP pull request, as much as possible in the
     comment thread of the pull request itself. Offline discussion will be
     summarized on the pull request comment thread.
-  - RFCs rarely go through this process unchanged, especially as alternatives
-    and drawbacks are shown. You can make edits, big and small, to the RFC to
+  - MCIPs rarely go through this process unchanged, especially as alternatives
+    and drawbacks are shown. You can make edits, big and small, to the MCIP to
     clarify or change the design, but make changes as new commits to the pull
     request, and leave a comment on the pull request explaining your changes.
     Specifically, do not squash or rebase commits after they are visible on the
     pull request.
   - At some point, a member of the team will propose a "motion for final
-    comment period" (FCP), along with a *disposition* for the RFC (merge, close,
+    comment period" (FCP), along with a *disposition* for the MCIP (merge, close,
     or postpone).
     - This step is taken when enough of the tradeoffs have been discussed that
     the team is in a position to make a decision. That does not require
-    consensus amongst all participants in the RFC thread (which is usually
-    impossible). However, the argument supporting the disposition on the RFC
+    consensus amongst all participants in the MCIP thread (which is usually
+    impossible). However, the argument supporting the disposition on the MCIP
     needs to have already been clearly articulated, and there should not be a
     strong consensus *against* that position outside of the team. Team
     members use their best judgment in taking this step, and the FCP itself
     ensures there is ample time and notification for stakeholders to push back
     if it is made prematurely.
-    - For RFCs with lengthy discussion, the motion to FCP is usually preceded by
+    - For MCIPs with lengthy discussion, the motion to FCP is usually preceded by
       a *summary comment* trying to lay out the current state of the discussion
       and major tradeoffs/points of disagreement.
     - Before actually entering FCP, *all* members of the team must sign off;
-    this is often the point at which many team members first review the RFC
+    this is often the point at which many team members first review the MCIP
     in full depth.
   - The FCP lasts 1 business days.
-  - In most cases, the FCP period is quiet, and the RFC is either merged or
+  - In most cases, the FCP period is quiet, and the MCIP is either merged or
     closed. However, sometimes substantial new arguments or ideas are raised,
-    the FCP is canceled, and the RFC goes back into development mode.
+    the FCP is canceled, and the MCIP goes back into development mode.
 
-## The RFC life-cycle
-[The RFC life-cycle]: #the-rfc-life-cycle
+## The MCIP life-cycle
+[The MCIP life-cycle]: #the-MCIP-life-cycle
 
-Once an RFC becomes "active" then authors may implement it and submit the
+Once an MCIP becomes "active" then authors may implement it and submit the
 feature as a pull request to the relevant repo. Being "active" is not a rubber
 stamp, and in particular still does not mean the feature will ultimately be
 merged; it does mean that in principle all the major stakeholders have agreed
 to the feature and are amenable to merging it.
 
-Furthermore, the fact that a given RFC has been accepted and is "active"
+Furthermore, the fact that a given MCIP has been accepted and is "active"
 implies nothing about what priority is assigned to its implementation, nor does
 it imply anything about whether a developer has been assigned the task of
 implementing the feature. While it is not *necessary* that the author of the
-RFC also write the implementation, it is by far the most effective way to see
-an RFC through to completion: authors should not expect that other project
+MCIP also write the implementation, it is by far the most effective way to see
+an MCIP through to completion: authors should not expect that other project
 developers will take on responsibility for implementing their accepted feature.
 
-Modifications to "active" RFCs can be done in follow-up pull requests. We
-strive to write each RFC in a manner that it will reflect the final design of
+Modifications to "active" MCIPs can be done in follow-up pull requests. We
+strive to write each MCIP in a manner that it will reflect the final design of
 the feature; but the nature of the process means that we cannot expect every
-merged RFC to actually reflect what the end result will be at the time of the
+merged MCIP to actually reflect what the end result will be at the time of the
 next major release.
 
-In general, once accepted, RFCs should not be substantially changed. Only very
+In general, once accepted, MCIPs should not be substantially changed. Only very
 minor changes should be submitted as amendments. More substantial changes
-should be new RFCs, with a note added to the original RFC. Exactly what counts
+should be new MCIPs, with a note added to the original MCIP. Exactly what counts
 as a "very minor change" is up to the team to decide; check
 [Team-specific guidelines] for more details.
 
 
-## Reviewing RFCs
-[Reviewing RFCs]: #reviewing-rfcs
+## Reviewing MCIPs
+[Reviewing MCIPs]: #reviewing-MCIPs
 
-While the RFC pull request is up, the team may schedule meetings with the
+While the MCIP pull request is up, the team may schedule meetings with the
 author and/or relevant stakeholders to discuss the issues in greater detail,
 and in some cases the topic may be discussed at a team meeting. In either
-case a summary from the meeting will be posted back to the RFC pull request.
+case a summary from the meeting will be posted back to the MCIP pull request.
 
-A team makes final decisions about RFCs after the benefits and drawbacks
+A team makes final decisions about MCIPs after the benefits and drawbacks
 are well understood. These decisions can be made at any time, but the team
-will regularly issue decisions. When a decision is made, the RFC pull request
+will regularly issue decisions. When a decision is made, the MCIP pull request
 will either be merged or closed. In either case, if the reasoning is not clear
 from the discussion in thread, the team will add a comment describing the
 rationale for the decision.
 
 
-## Implementing an RFC
-[Implementing an RFC]: #implementing-an-rfc
+## Implementing an MCIP
+[Implementing an MCIP]: #implementing-an-MCIP
 
-Some accepted RFCs represent vital features that need to be implemented right
-away. Other accepted RFCs can represent features that can wait until some
-arbitrary developer feels like doing the work. Every accepted RFC has an
+Some accepted MCIPs represent vital features that need to be implemented right
+away. Other accepted MCIPs can represent features that can wait until some
+arbitrary developer feels like doing the work. Every accepted MCIP has an
 associated epic tracking its implementation in a repository; thus that
 associated epic can be assigned a priority via the triage process that the
 team uses for all issues in a repository.
 
-The author of an RFC is not obligated to implement it. Of course, the RFC
+The author of an MCIP is not obligated to implement it. Of course, the MCIP
 author (like any other developer) is welcome to post an implementation for
-review after the RFC has been accepted.
+review after the MCIP has been accepted.
 
-If you are interested in working on the implementation for an "active" RFC, but
+If you are interested in working on the implementation for an "active" MCIP, but
 cannot determine if someone else is already working on it, feel free to ask
 (e.g. by leaving a comment on the associated issue).
 
 
-## RFC Postponement
-[RFC Postponement]: #rfc-postponement
+## MCIP Postponement
+[MCIP Postponement]: #MCIP-postponement
 
-Some RFC pull requests are tagged with the "postponed" label when they are
-closed (as part of the rejection process). An RFC closed with "postponed" is
+Some MCIP pull requests are tagged with the "postponed" label when they are
+closed (as part of the rejection process). An MCIP closed with "postponed" is
 marked as such because we want neither to think about evaluating the proposal
 nor about implementing the described feature until some time in the future, and
 we believe that we can afford to wait until then to do so. Historically,
@@ -224,11 +224,11 @@ we believe that we can afford to wait until then to do so. Historically,
 requests may be re-opened when the time is right. We don't have any formal
 process for that, you should ask members of the relevant team.
 
-Usually an RFC pull request marked as "postponed" has already passed an
+Usually an MCIP pull request marked as "postponed" has already passed an
 informal first round of evaluation, namely the round of "do we think we would
-ever possibly consider making this change, as outlined in the RFC pull request,
+ever possibly consider making this change, as outlined in the MCIP pull request,
 or some semi-obvious variation of it." (When the answer to the latter question
-is "no", then the appropriate response is to close the RFC, not postpone it.)
+is "no", then the appropriate response is to close the MCIP, not postpone it.)
 
 
 ### Help this is all too informal!
@@ -252,4 +252,4 @@ This repository is licensed as:
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed as above, without any additional terms or conditions.
 
 
-[RFC repository]: https://github.com/mobilecoinfoundation/rfcs
+[MCIP repository]: https://github.com/mobilecoinfoundation/MCIPs

--- a/consensus.md
+++ b/consensus.md
@@ -1,3 +1,3 @@
-# RFC policy - Consensus
+# MCIP policy - Consensus
 
 There are no additional requirements for consensus team systems beyond those in the top-level README, though that may change.

--- a/fog.md
+++ b/fog.md
@@ -1,3 +1,3 @@
-# RFC policy - Fog
+# MCIP policy - Fog
 
 There are no additional requirements for fog team systems beyond those in the top-level README, though that may change.

--- a/text/0001-dynamic-fees-v1.md
+++ b/text/0001-dynamic-fees-v1.md
@@ -1,6 +1,6 @@
 - Feature Name: Dynamic Fees V1 (Configurable Fees)
 - Start Date: (2021-04-20)
-- RFC PR: [mobilecoinfoundation/rfcs#1](https://github.com/mobilecoinfoundation/rfcs/pull/1)
+- MCIP PR: [mobilecoinfoundation/mcips#1](https://github.com/mobilecoinfoundation/mcips/pull/1)
 - MobileCoin Epic: MCC-2301
 
 # Summary
@@ -94,12 +94,12 @@ The primary rationale, then, is that this is "good enough" for right now, and we
 # Prior art
 [prior-art]: #prior-art
 
-Unfortunately, due to the limited scope of this PR, prior art is going to be difficult to discuss. There is obviously a much larger conversation to be had about Etherium gas, Bitcoin transaction fees, etc., and how MobileCoin fees differ from them, but that honestly belongs in a future RFC. This is about doing the minimum viable to get us to a baseline fee-adjustment strategy, without compromising our ability to respond to denial of service attacks.
+Unfortunately, due to the limited scope of this PR, prior art is going to be difficult to discuss. There is obviously a much larger conversation to be had about Etherium gas, Bitcoin transaction fees, etc., and how MobileCoin fees differ from them, but that honestly belongs in a future MCIP. This is about doing the minimum viable to get us to a baseline fee-adjustment strategy, without compromising our ability to respond to denial of service attacks.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- There are no unresolved questions which should be resolved by this RFC.
+- There are no unresolved questions which should be resolved by this MCIP.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0003-encrypted-memos.md
+++ b/text/0003-encrypted-memos.md
@@ -1,6 +1,6 @@
 - Feature Name: Encrypted Memos
 - Start Date: (2021-06-18)
-- RFC PR: [mobilecoinfoundation/mcips#3](https://github.com/mobilecoinfoundation/mcips/pull/3)
+- MCIP PR: [mobilecoinfoundation/mcips#3](https://github.com/mobilecoinfoundation/mcips/pull/3)
 - MobileCoin Epic: None
 
 # Summary
@@ -280,7 +280,7 @@ and for many contributions that helped shape the proposal.
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- There are no unresolved questions which should be resolved by this RFC.
+- There are no unresolved questions which should be resolved by this MCIP.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0004-recoverable-transaction-history.md
+++ b/text/0004-recoverable-transaction-history.md
@@ -1,6 +1,6 @@
 - Feature Name: Recoverable Transaction History
 - Start Date: (2021-06-18)
-- RFC PR: [mobilecoinfoundation/mcips#4](https://github.com/mobilecoinfoundation/mcips/pull/4)
+- MCIP PR: [mobilecoinfoundation/mcips#4](https://github.com/mobilecoinfoundation/mcips/pull/4)
 - MobileCoin Epic: None
 
 # Summary
@@ -339,7 +339,7 @@ that helped shape the proposal.
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- There are no unresolved questions which should be resolved by this RFC.
+- There are no unresolved questions which should be resolved by this MCIP.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities


### PR DESCRIPTION
We renamed this repo from mobilecoinfoundation/rfcs (Request for Comment) to mobilecoinfoundation/mcips (MobileCoin Improvement Proposal). This PR changes the text in the READMEs and template to match.