### PR TITLE
Reserved Subaddresses

### DIFF
--- a/text/0004-recoverable-transaction-history.md
+++ b/text/0004-recoverable-transaction-history.md
@@ -117,7 +117,7 @@ that went to the change subaddress.
 ## Change subaddress
 
 The "change subaddress" is a new standard subaddress, like the default subaddress. It should be used when sending change outputs.
-It is specified to be subaddress index `u64::MAX`.
+It is specified to be subaddress index `u64::MAX-1`.
 
 The change subaddress should be kept secret, so that only authentic 0x0200 Destination memos will pass validation.
 

--- a/text/0004-recoverable-transaction-history.md
+++ b/text/0004-recoverable-transaction-history.md
@@ -23,7 +23,7 @@ history given only the private keys of the user, by fetching all of the user's T
 decoding and validating the memos.
 
 Some additional ancillary parts of the proposal:
-- Change subaddress is standardized to subaddress index `u64::MAX`.
+- Change subaddress is standardized to subaddress index `u64::MAX - 1`.
 - Clients should always produce a change output even if the change is zero, in order to have a place to put
   the destination memo.
 - A standard 16-byte hash of a public address is specified, which may be useful elsewhere.

--- a/text/0004-recoverable-transaction-history.md
+++ b/text/0004-recoverable-transaction-history.md
@@ -4,6 +4,8 @@
 - Implementation: [mobilecoinfoundation/mobilecoin#814](https://github.com/mobilecoinfoundation/mobilecoin/pull/814)
 
 *Note:* This MCIP describes a memo which has had its size adjusted from 46 to 66 in MCIP #24.  That [MCIP lists the changed byte tables](0024-increase-memo-field-size.md#this-is-an-update-to-4).
+*Note:* This MCIP initially set the change subaddress index to `1`. This was updated in [MCIP #36](https://github.com/mobilecoinfoundation/mcips/pull/36) to `u64::MAX`.
+
 # Summary
 [summary]: #summary
 
@@ -21,7 +23,7 @@ history given only the private keys of the user, by fetching all of the user's T
 decoding and validating the memos.
 
 Some additional ancillary parts of the proposal:
-- Change subaddress is standardized to subaddress index 1.
+- Change subaddress is standardized to subaddress index `u64::MAX`.
 - Clients should always produce a change output even if the change is zero, in order to have a place to put
   the destination memo.
 - A standard 16-byte hash of a public address is specified, which may be useful elsewhere.
@@ -115,7 +117,7 @@ that went to the change subaddress.
 ## Change subaddress
 
 The "change subaddress" is a new standard subaddress, like the default subaddress. It should be used when sending change outputs.
-It is specified to be subaddress index 1.
+It is specified to be subaddress index `u64::MAX`.
 
 The change subaddress should be kept secret, so that only authentic 0x0200 Destination memos will pass validation.
 

--- a/text/0004-recoverable-transaction-history.md
+++ b/text/0004-recoverable-transaction-history.md
@@ -4,7 +4,7 @@
 - Implementation: [mobilecoinfoundation/mobilecoin#814](https://github.com/mobilecoinfoundation/mobilecoin/pull/814)
 
 *Note:* This MCIP describes a memo which has had its size adjusted from 46 to 66 in MCIP #24.  That [MCIP lists the changed byte tables](0024-increase-memo-field-size.md#this-is-an-update-to-4).
-*Note:* This MCIP initially set the change subaddress index to `1`. This was updated in [MCIP #36](https://github.com/mobilecoinfoundation/mcips/pull/36) to `u64::MAX`.
+*Note:* This MCIP initially set the change subaddress index to `1`. This was updated in [MCIP #36](https://github.com/mobilecoinfoundation/mcips/pull/36) to `u64::MAX - 1`.
 
 # Summary
 [summary]: #summary

--- a/text/0036-reserved-subaddresses.md
+++ b/text/0036-reserved-subaddresses.md
@@ -57,6 +57,35 @@ with subaddresses already assigned by the desktop wallet.
 This is reserving a lot of subaddresses. However, if later it turns out we need to
 give most of them back, that should be fine.
 
+It turns out that the full-service desktop wallet is already sending change to a change subaddress,
+but only in certain configurations, and it is using subaddress index 1 for this.
+This proposal will require full-service to start using `u64::MAX - 1` after block version 1,
+and can have backwards compatibility support for subaddress index 1 in blocks before that version.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+An alternative would have been to use change subaddress index 1 for all clients, and not use `u64::MAX - 1`.
+
+However, this has a major drawback for anyone using `mobilecoind` today, which is that they have been using
+subaddress index 1 with contacts. So they have already handed that subaddress out to their contacts, and they
+have no practical ability to change it now that they've given it away. If they are an exchange, customers may
+still deposit money to that address.
+
+Additionally, the change subaddress index plays a critical role in RTH memo validation in MCIP #4.
+It is regarded as a secret -- anyone who knows your change subaddress is able to send you destination memos
+that your clients will treat as valid. If you are an exchange and someone knows your change subaddress, then
+they can potentially forge bad destination memos and defraud you.
+
+Therefore, it is safer to use `u64::MAX - 1`, a subaddress index that has never been used by any client before,
+as the change subaddress index, and to migrate full-service to use this before RTH memos exist in the wild.
+
+*Specifically, full-service, and any either client, should NEVER treat a destination memos as valid if it comes
+on the subaddress of index 1.*
+
+Since this means that we cannot standardize on `1` as the change subaddress index, `u64::MAX - 1` is the best
+remaining option.
+
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 

--- a/text/0036-reserved-subaddresses.md
+++ b/text/0036-reserved-subaddresses.md
@@ -1,7 +1,7 @@
 - Feature Name: Reserved Subaddresses
 - Start Date: (2022-04-10)
 - MCIP PR: [mobilecoinfoundation/mcips#36](https://github.com/mobilecoinfoundation/mcips/pull/36)
-- Tracking Issue: TODO
+- Tracking Issue: https://github.com/mobilecoinfoundation/mobilecoin/issues/1787
 
 [summary]: #summary
 

--- a/text/0036-reserved-subaddresses.md
+++ b/text/0036-reserved-subaddresses.md
@@ -7,10 +7,14 @@
 
 Subaddress indices are unsigned 64-bit numbers.
 
-The indices with high bit set are reserved for "special purposes".
+The indices with high bit set are reserved for "special purposes", and should
+not be assigned to individual contacts by desktop wallets that are using subaddresses this way.
+
+`u64::MAX` will be reserved for an "invalid / none" value.
 
 [mobilecoinfoundation/mcips#4](https://github.com/mobilecoinfoundation/mcips/pull/4) will be updated,
-changing the change subaddress from `1` to `u64::MAX`.
+changing the change subaddress from `1` to `u64::MAX - 1`.
+
 Subsequent reserved indices will count down from there.
 
 # Motivation
@@ -38,12 +42,14 @@ into a desktop wallet.
 
 Subaddress indices with the high bit set are reserved for special purposes.
 
-Examples:
-* The "change subaddress" from [MCIP #4](https://github.com/mobilecoinfoundation/mcips/pull/4)
-* The "gift code subaddress" from [MCIP #32](https://github.com/mobilecoinfoundation/mcips/pull/32)
-
 These will be assigned numbers counting down from `u64::MAX`. This avoids collisions
 with subaddresses already assigned by the desktop wallet.
+
+| Subaddress index | Purpose         |
+| ---------------- | --------------- |
+| `u64::MAX`       | Invalid / None      |
+| `u64::MAX - 1`   | Change subaddress [MCIP #4](https://github.com/mobilecoinfoundation/mcips/pull/4)      |
+| `u64::MAX - 2`   | Gift code subaddress [MCIP #32](https://github.com/mobilecoinfoundation/mcips/pull/32) |
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0036-reserved-subaddresses.md
+++ b/text/0036-reserved-subaddresses.md
@@ -5,7 +5,7 @@
 
 [summary]: #summary
 
-Subaddress indices are unsigned 64-bit numbers.
+Subaddress indices are unsigned 64-bit integers.
 
 The indices with high bit set are reserved for "special purposes", and should
 not be assigned to individual contacts by desktop wallets that are using subaddresses this way.

--- a/text/0036-reserved-subaddresses.md
+++ b/text/0036-reserved-subaddresses.md
@@ -1,0 +1,62 @@
+- Feature Name: Reserved Subaddresses
+- Start Date: (2022-04-10)
+- MCIP PR: [mobilecoinfoundation/mcips#36](https://github.com/mobilecoinfoundation/mcips/pull/36)
+- Tracking Issue: TODO
+
+[summary]: #summary
+
+Subaddress indices are unsigned 64-bit numbers.
+
+The indices with high bit set are reserved for "special purposes".
+
+[mobilecoinfoundation/mcips#4](https://github.com/mobilecoinfoundation/mcips/pull/4) will be updated,
+changing the change subaddress from `1` to `u64::MAX`.
+Subsequent reserved indices will count down from there.
+
+# Motivation
+[motivation]: #motivation
+
+In developing new features, we have discovered that sometimes, we want to reserve particular subaddress
+indices for specific purposes. This is particularly helpful for mobile wallets which are designed to
+be used with "linked devices" that share your private keys. By using the subaddress index to represent
+information about a `TxOut`, they can ensure that other linked devices will all see this information,
+without needing to create another synchronization mechnaism.
+
+A good example of this is the "change subaddress" introduced in
+[mobilecoinfoundation/mcips#4](https://github.com/mobilecoinfoundation/mcips/pull/4).
+
+However, this is at odds with how the desktop wallets use subaddresses. The desktop wallets
+assign different subaddresses to different contacts, counting up from 1.
+
+To avoid collisions and promote compatibility, we want to ensure that the change subaddress and other
+special subaddresses will never be used for contacts by desktop wallets. This will help desktop wallets
+to be able to make as much sense of this information as possible if a user imports their mobile wallet keys
+into a desktop wallet.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Subaddress indices with the high bit set are reserved for special purposes.
+
+Examples:
+* The "change subaddress" from [MCIP #4](https://github.com/mobilecoinfoundation/mcips/pull/4)
+* The "gift code subaddress" from [MCIP #32](https://github.com/mobilecoinfoundation/mcips/pull/32)
+
+These will be assigned numbers counting down from `u64::MAX`. This avoids collisions
+with subaddresses already assigned by the desktop wallet.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+This is reserving a lot of subaddresses. However, if later it turns out we need to
+give most of them back, that should be fine.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+None at this time.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+None at this time.


### PR DESCRIPTION
A proposal to reserve a range of subaddresses for future purposes, to promote compatibility.

[Rendered Proposal](https://github.com/garbageslam/mcips/blob/reserved-subaddresses/text/0036-reserved-subaddresses.md)