### PR TITLE
Update 0029-block-streaming.md

### DIFF
--- a/text/0029-block-streaming.md
+++ b/text/0029-block-streaming.md
@@ -1,8 +1,8 @@
-* Feature Name: `block_streaming`
-* Start Date: 2022-03-01
-* MCIP PR:
+- Feature Name: `block_streaming`
+- Start Date: 2022-03-01
+- MCIP PR:
   [mcips #29](https://github.com/mobilecoinfoundation/mcips/pull/29)
-* Tracking Issue:
+- Tracking Issue:
   [mobilecoin #1433](https://github.com/mobilecoinfoundation/mobilecoin/issues/1433)
 
 


### PR DESCRIPTION
Fixing the format on the header/metadata from * to - as bullets. This formatting is required by the parser for our website's navigation menu. 

The rendered proposal is now re-rendered on our website:
https://mobilecoin.com/proposals/block-streaming

Alternative solution: We could update our parser to support both types of bullets.