### PR TITLE
Update 0043-block-metadata.md

### DIFF
--- a/text/0043-block-metadata.md
+++ b/text/0043-block-metadata.md
@@ -1,7 +1,7 @@
-* Feature Name: `block_metadata`
-* Start Date: 2022-05-24
-* MCIP PR: [mobilecoinfoundation/mcips#43](https://github.com/mobilecoinfoundation/mcips/pull/43)
-* Tracking Issue: https://github.com/mobilecoinfoundation/mobilecoin/issues/2104
+- Feature Name: `block_metadata`
+- Start Date: 2022-05-24
+- MCIP PR: [mobilecoinfoundation/mcips#43](https://github.com/mobilecoinfoundation/mcips/pull/43)
+- Tracking Issue: https://github.com/mobilecoinfoundation/mobilecoin/issues/2104
 
 Contents:
 


### PR DESCRIPTION
Fixing the format on the header/metadata from * to - as bullets. This formatting is required by the parser for our website's navigation menu.

The rendered proposal is now re-rendered on our website:
https://mobilecoin.com/proposals/block-metadata

Alternative solution: We could update our parser to support both types of bullets.