### PR TITLE
TxSummary digest

### DIFF
--- a/text/0050-tx-summary-digest.md
+++ b/text/0050-tx-summary-digest.md
@@ -1,0 +1,204 @@
+- Feature Name: tx_summary_digest
+- Start Date: 2022-10-08
+- MCIP PR: [mobilecoinfoundation/mcips#0050](https://github.com/mobilecoinfoundation/mcips/pull/0050)
+- Tracking Issue: [mobilecoinfoundation/mobilecoin#2686](https://github.com/mobilecoinfoundation/mobilecoin/issues/2686)
+
+# Summary
+[summary]: #summary
+
+Introduce an object called `TxSummary` which is significantly smaller than a `Tx`,
+but which with small additional data can be used to verify the values of inputs
+and outputs, and the destinations of the outputs, in a given `Tx`.
+
+Where previously the `extended_message_digest` is signed by Ring MLSAGs
+in a transaction, now a new digest formed using that digest and the `TxSummary` will
+be signed instead.
+
+# Motivation
+[motivation]: #motivation
+
+Hardware wallets such as Ledger have an expectation that when the user signs a
+transaction, the device can display information about how much money will be sent
+to what addresses as a result of this transaction, and that the device can verify
+that this information is correct.
+
+However, with the status quo, the only way that this can be accomplished is to put
+the entire `Tx` on the device so that it can verify the `extended_message_digest`,
+because the `extended_message_digest` is the only thing that connects the `MLSAG`
+that the device is signing to the rest of the `Tx`.
+
+This increases the amount of data that has to be sent to the device from a few kb
+to `> 100kb` in the worst case. This is because Merkle proofs are each e.g. 40 bytes
+per merkle element and with a height of 20-30, so they may end up being 1 KB each.
+Then, there is a merkle proof for each `TxIn` (at most 16) and each mixin (11 per `TxIn`).
+
+Having to transfer this much data to a tiny device will slow down the user experience
+noticeably, and will greatly increase the complexity of implementation, because the device
+has much less memory than this and would have to use some kind of "windowing" strategy
+to compute the hash.
+
+On the other hand, if the digest that the Ring MLSAGs sign is changed as proposed, then
+we only need to send 32 bytes followed by the `TxSummary` to prove to the device where
+the digest that the MLSAG's are signing comes from, and so what the outcome of the `Tx` is.
+So we can avoid sending all merkle proofs, bulletproofs, encrypted fog hints, memos, etc.
+and reduce the traffic with the device by perhaps a factor of 10 or so in the worst case,
+as well as reducing the implementation complexity.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+A `TxSummary` is an object much like the `TxPrefix`, but where instead of the `TxIn`
+objects, the corresponding `pseudo_output_commitments` are stored.
+
+There is exactly one possible `TxSummary` for a given `Tx`.
+
+The `TxSummary` contains:
+* The list of outputs (omitting "extra" parts like encrypted fog hint and encrypted memo).
+* The list of pseudo_output_commitments (commitments to the values of the true inputs)
+  * Any input rules associated to these inputs (if they are [MCIP 42](https://github.com/mobilecoinfoundation/mcips/pull/42) signed contingent inputs)
+* The fee and fee token id
+* The tombstone block
+
+During transaction construction, the signer computes the extended message digest as before,
+but now creates a merlin transcript using that 32-byte digest, followed by digesting the
+`TxSummary`. The MLSAG's (except for SCIs) will sign 32-bytes extracted from this digest.
+The verifier similarly computes this
+`extended-message-and-tx-summary digest` and verifies that the MLSAGs sign this.
+
+When a hardware wallet is asked to sign an MLSAG, we can give it now the `extended_message_digest`
+and the `TxSummary`, and it can compute the appropriate digest from this for the MLSAG to sign.
+
+Additionally, we can provide it the `TxSummaryUnblindingData`, which inclues:
+* For each pseudo-output-commitment, the amount (value and token id), and blinding factor.
+* For each output, the target public address, the amount, and the `tx_private_key`, unless
+  it is part of an SCI. In that case we can unblind it using the amount shared secret in the
+  SCI input rules to find it's value, and we can't know
+  exactly what address is the destination, except that it's associated to the SCI.
+* The block version these outputs all targetted.
+
+These data are not very large and allow the hardware wallet to verify the amounts of all
+inputs and outputs in the `TxSummary` and to verify the destination of each output.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The `TxSummary` is a new object with the following schema, which is constructed
+before signing a `Tx`.
+
+```mermaid
+classDiagram
+direction BT
+TxOutSummary --> TxSummary
+TxInSummary --> TxSummary
+TxSummary: Vec~TxOutSummary~ outputs
+TxSummary: Vec~TxInSummary~ inputs
+TxSummary: uint64 fee_value
+TxSummary: uint64 fee_token_id
+TxSummary: uint64 tombstone_block
+TxSummary: new(&TxPrefix, &[TxInSummary])
+TxOutSummary: CompressedRistrettoPublic public_key
+TxOutSummary: CompressedRistrettoPublic target_key
+TxOutSummary: MaskedAmount masked_amount
+TxOutSummary: from(&TxOut)
+TxInSummary: CompressedCommitment pseudo_output_commitment
+TxInSummary: Option~InputRules~ input_rules
+```
+
+In block version 2, MLSAG's (other than the MCIP 42 Signed Contingent Inputs) sign
+the `extended_message_digest`. We propose that they should now sign the `extended_message_and_tx_summary_digest`,
+which is defined as follows, using the `mc-crypto-digestible` scheme with a Merlin transcript:
+
+```rust
+let mut transcript =
+    MerlinTranscript::new(EXTENDED_MESSAGE_AND_TX_SUMMARY_DOMAIN_TAG.as_bytes());
+extended_message.append_to_transcript(b"extended_message", &mut transcript);
+tx_summary.append_to_transcript(b"tx_summary", &mut transcript);
+
+let mut extended_message_and_tx_summary_digest = [0u8; 32];
+transcript.extract_digest(&mut extended_message_and_tx_summary_digest);
+```
+
+This digest is computable given only the 32 byte extended message digest, and the
+`TxSummary`, which are together much smaller than an entire `Tx`.
+
+A hardware wallet which is asked to sign an MLSAG can expect to see that 32 byte digest
+and the `TxSummary`. From a security point of view, it can know that it is intractable
+for someone to find a different `TxSummary` that produces the same `extended_message_and_tx_summary`
+domain tag. The hardware wallet also knows how the validators will compute the `extended_message_and_tx_summary`
+based on the `Tx`, and knows that it is infeasible for anyone to find another `Tx` that has the same digest here.
+
+A hardware wallet can also expect to be supplied with the `TxSummaryUnblindingData` which allows it to see
+as much information as possible about where funds are coming from and where they are going in the `Tx`.
+
+```mermaid
+classDiagram
+direction BT
+TxOutUnblindingData --> TxSummaryUnblindingData
+TxSummaryUnblindingData: uint32 block_version
+TxSummaryUnblindingData: Vec~UnmaskedAmount~ inputs
+TxSummaryUnblindingData: Vec~TxOutUnblindingData~ outputs
+TxOutUnblindingData: UnmaskedAmount amount
+TxOutUnblindingData: Option<PublicAddress> address
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+The main reason not to do this is that it somewhat increases the complexity of transaction validation.
+
+It is also inelegant in that we hash a bunch of information into the extended message (by hashing the `TxPrefix`),
+and then we hash it again via the `TxSummary`, because the `TxSummary` contains some of this information duplicated.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+Although doing this increases the complexity of transaction validation, not doing it considerably increases
+the complexity of hardware wallet implementation and could delay the ship date of hardware wallet support.
+
+Although it is inelegant to hash a bunch of stuff a second time, in practical terms, the cost of doing this is very low.
+
+There are many things that are inelegant about our current `Tx` structure. It is inelegant that the `TxPrefix` hash is not
+the only thing that MLSAG's sign and that extra stuff from `SignatureRctBulletproofs` is signed. It would be better if this
+`TxSummary` object *were* the `TxPrefix` to some extent, and the merkle proofs, bulletproofs, and other extra stuff were
+digested before that. Then we would not need to have an extra round of hashing things at the end.
+
+However, we do not propose at this time to completely change the `Tx` structure to fix these issues, as this would be
+a very complicated breaking change.
+
+Instead, we view this current proposal as the simplest and most straightforward proposal that will meet the needs of
+hardware wallets and help them to avoid complexities around streaming too much data and having to create a state machine to
+compute a proper merlin digest of the entire `Tx` object, which would also make the user experience significantly slower.
+
+## SCI support, definition of `TxSummaryUnblindingData`.
+
+We have tried to future-proof this design against [MCIP 42](https://github.com/mobilecoinfoundation/mcips/pull/42) Signed Contingent Inputs being present in the `Tx`.
+However, these cannot even be used until block version 3, and may not be in common use at the time that hardware wallet support
+is actually shipped.
+
+It may be that hardware wallets will initially cut scope and not seek to support that feature. Then, they could cut the `InputRules`
+from the `TxInSummary` and they could assume that `address` is mandatory in `TxOutSummary::address`.
+
+They might also seek to compress or remove redundancy in some of these structures. Strictly speaking, the `TxSummaryUnblindingData`
+has no connection to MobileCoin protocol rules, it's rather a detail of the hardware wallets, so it is not necessary to create an
+MCIP for this.
+
+We view it as the prerogative of hardware wallets to define their own wire format as they see fit and carry out whatever compression / improvements they
+think are appropriate. It seems worthwhile to define a "proof of concept" `TxSummaryUnblindingData` object and show how it can be validated
+against a `TxSummary` to provide at least a baseline or starting point for such projects, since if there is actually a defect in the
+design that prevents `TxSummary` from being unblinded effectively, it would defeat the purpose of this improvement proposal.
+
+# Prior art
+[prior-art]: #prior-art
+
+None that we know of.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+None at this time.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+If more fields are added to `Tx` or `TxPrefix` that would be interesting for hardware wallets to have visibility on, we should also add them
+to `TxSummary`.

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -213,7 +213,7 @@ M[concatenation] --> N
 N[extended_message -many bytes-]
 ```
 
-In block version 2, we changed this (in [MCIP 25](https://github.com/mobilecoinfoundation/mcips/pull/25)) so that the Ring MLSAG's sign the
+In block version 2, we changed this (in [MCIP 25](0025-confidential-token-ids.md)) so that the Ring MLSAG's sign the
 "extended message digest" which is computed roughly as follows:
 
 ```mermaid

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Introduce an object called `TxSummary` which is significantly smaller than a `Tx`,
+Introduce a `TxSummary` that is significantly smaller than a `Tx`,
 but which with small additional data can be used to verify the values of inputs
 and outputs, and the destinations of the outputs, when a device is asked to sign
 a `RingMLSAG` for a new transaction.
@@ -28,10 +28,10 @@ the entire `Tx` on the device so that it can verify the `extended_message_digest
 because the `extended_message_digest` is the only thing that connects the `MLSAG`
 that the device is signing to the rest of the `Tx`.
 
-This increases the amount of data that has to be sent to the device from a few kb
-to `> 100kb` in the worst case. This is because Merkle proofs are each e.g. 40 bytes
-per merkle element and with a height of 20-30, so they may end up being 1 KB each.
-Then, there is a merkle proof for each `TxIn` (at most 16) and each mixin (11 per `TxIn`).
+This increases the amount of data that has to be sent to the device from a few KiB
+to over 100KiB in the worst case. This is because Merkle proofs are around 40 bytes
+per merkle element. With a height of 20-30 they may end up being 1 KB each.
+Then, there is a Merkle proof for each `TxIn` (at most 16) and each mixin (11 per `TxIn`).
 
 Having to transfer this much data to a tiny device will slow down the user experience
 noticeably, and will greatly increase the complexity of implementation, because the device
@@ -41,7 +41,7 @@ to compute the hash.
 On the other hand, if the digest that the Ring MLSAGs sign is changed as proposed, then
 we only need to send 32 bytes followed by the `TxSummary` to prove to the device where
 the digest that the MLSAG's are signing comes from, and so what the outcome of the `Tx` is.
-So we can avoid sending all merkle proofs, bulletproofs, encrypted fog hints, memos, etc.
+So we can avoid sending all Merkle proofs, bulletproofs, encrypted fog hints, memos, etc.
 and reduce the traffic with the device by perhaps a factor of 10 or so in the worst case,
 as well as reducing the implementation complexity.
 
@@ -55,8 +55,8 @@ There is exactly one possible `TxSummary` for a given `Tx`.
 
 The `TxSummary` contains:
 * The list of outputs (omitting "extra" parts like encrypted fog hint and encrypted memo).
-* The list of pseudo_output_commitments (commitments to the values of the true inputs)
-  * Any input rules associated to these inputs (if they are [MCIP 31](https://github.com/mobilecoinfoundation/mcips/pull/31) signed contingent inputs)
+* The list of `pseudo_output_commitments` (commitments to the values of the true inputs)
+  * Any input rules associated to these inputs (if they are [MCIP 31](0031-transactions-with-contingent-inputs.md) signed contingent inputs)
 * The fee and fee token id
 * The tombstone block
 
@@ -70,7 +70,7 @@ When a hardware wallet is asked to sign an MLSAG, we can give it now the `extend
 and the `TxSummary`, and it can compute the appropriate digest from this for the MLSAG to sign.
 
 Additionally, we can provide it the `TxSummaryUnblindingData`, which inclues:
-* For each pseudo-output-commitment, the amount (value and token id), and blinding factor.
+* For each `pseudo_output_commitment`, the amount (value and token id), and blinding factor.
 * For each output, the target public address, the amount, and the `tx_private_key`, unless
   it is part of an SCI. In that case we can unblind it using the amount shared secret in the
   SCI input rules to find it's value, and we can't know
@@ -172,7 +172,7 @@ The hardware wallet also knows how the validators will compute the `extended_mes
 based on the `Tx`, and knows that it is infeasible for anyone to find another `Tx` that has the same digest here.
 So, an attacker (on the computer) could give the device an improperly formed `TxSummary` and lie to the device
 this way, but the attacker will not be able to get consensus to accept those signatures. The device therefore
-knows that the either the `TxSummary` is accurate, or it's signature doesn't matter because the `Tx` will not
+knows that either the `TxSummary` is accurate, or it's signature doesn't matter because the `Tx` will not
 be accepted.
 
 A hardware wallet can also expect to be supplied with the `TxSummaryUnblindingData` which allows it to see
@@ -224,7 +224,7 @@ Instead, we view this current proposal as the simplest and most straightforward 
 hardware wallets and help them to avoid complexities around streaming too much data and having to create a state machine to
 compute a proper merlin digest of the entire `Tx` object, which would also make the user experience significantly slower.
 
-## SCI support, definition of `TxSummaryUnblindingData`.
+## SCI support, definition of `TxSummaryUnblindingData`
 
 We have tried to future-proof this design against [MCIP 31](https://github.com/mobilecoinfoundation/mcips/pull/31) Signed Contingent Inputs being present in the `Tx`.
 However, these cannot even be used until block version 3, and may not be in common use at the time that hardware wallet support

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -349,6 +349,11 @@ did not create it, and we have no visibility into any of this, and there is no w
 are present in the `TxSummary` in order to convince the device that this is really the case, and the host computer is not just withholding evidence in order
 to manipulate the logic in the device.
 
+**Note**: In the final draft, we decided to include a 32-byte merlin digest of the input rules in the TxSummary, rather than just a flag. This allows that
+if in the future we decide that the device needs visibility into the input rules, we can add this without a breaking change to the consensus enclave.
+However, in the decision tree for the device, the device does not actually check this digest against anything, it simply checks if this digest is present
+to infer whether this input has input rules.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -165,10 +165,15 @@ A hardware wallet which is asked to sign an MLSAG can expect to see that 32 byte
 and the `TxSummary`.
 
 **Security**:
-From a security point of view, it can know that it is intractable
-for someone to find a different `TxSummary` that produces the same `extended_message_and_tx_summary`
-domain tag. The hardware wallet also knows how the validators will compute the `extended_message_and_tx_summary`
+From a security point of view, the hardware wallet can know that it is intractable
+for someone to find a different `TxSummary` that produces the same `extended_message_and_tx_summary` digest,
+so if it signs the MLSAG, this is the only thing that it can be committing to.
+The hardware wallet also knows how the validators will compute the `extended_message_and_tx_summary` digest
 based on the `Tx`, and knows that it is infeasible for anyone to find another `Tx` that has the same digest here.
+So, an attacker (on the computer) could give the device an improperly formed `TxSummary` and lie to the device
+this way, but the attacker will not be able to get consensus to accept those signatures. The device therefore
+knows that the either the `TxSummary` is accurate, or it's signature doesn't matter because the `Tx` will not
+be accepted.
 
 A hardware wallet can also expect to be supplied with the `TxSummaryUnblindingData` which allows it to see
 as much information as possible about where funds are coming from and where they are going in the `Tx`.

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -355,8 +355,11 @@ For outputs, we can use the following decision tree:
 This is reasonable because it is never sensible for a person to be a counterparty to their own Signed Contingent Input. `InputRules` can only be used
 to constrain the person who uses a particular signed input in a transaction. If you are in fact the signer of the input, you could always remove the input
 rules and sign the input normally, and your transaction would be valid if it were valid before (in strictly more cases). A real client would always prefer
-not to make their own input into an SCI, for simplicity. Regardless, in the above decision tree, we test if a `TxOut` belongs to the signer using view-key
-matching before reaching the last case and checking the `associated_to_input_rules` flag.
+not to make their own input into an SCI, for simplicity. This observation applies no matter what future kinds of `InputRules` we create -- if you are capable
+of signing for a given input on your own, you can always bypass any `InputRules` on an SCI by just signing that input, not as an SCI.
+Regardless, in the above decision tree, we test if a `TxOut` belongs to the signer using view-key
+matching before reaching the last case and checking the `associated_to_input_rules` flag. So if we do actually own an input, we will identify it thusly, even
+if it happens to be associated to some `InputRules`.
 
 For inputs, we can use the following decision tree:
 * Given a `TxInSummary`, the `TxSummaryUnblindingData` contains a corresponding `UnmaskedAmount`.

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -8,7 +8,8 @@
 
 Introduce an object called `TxSummary` which is significantly smaller than a `Tx`,
 but which with small additional data can be used to verify the values of inputs
-and outputs, and the destinations of the outputs, in a given `Tx`.
+and outputs, and the destinations of the outputs, when a device is asked to sign
+a `RingMLSAG` for a new transaction.
 
 Where previously the `extended_message_digest` is signed by Ring MLSAGs
 in a transaction, now a new digest formed using that digest and the `TxSummary` will
@@ -138,22 +139,28 @@ TxSummaryUnblindingData: uint32 block_version
 TxSummaryUnblindingData: Vec~UnmaskedAmount~ inputs
 TxSummaryUnblindingData: Vec~TxOutUnblindingData~ outputs
 TxOutUnblindingData: UnmaskedAmount amount
-TxOutUnblindingData: Option<PublicAddress> address
+TxOutUnblindingData: Option~PublicAddress~ address
 ```
+
+Strictly speaking, the `TxSummaryUnblindingData` is not part of the MobileCoin network's protocol rules,
+it's rather a detail of the hardware wallets, and they might choose not to use this schema and do their
+own thing. However, it is useful as a proof of concept, to validate that the `TxSummary` design does
+actually achieve the goals we set out. This at least provides a starting point for hardware wallet projects.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 The main reason not to do this is that it somewhat increases the complexity of transaction validation.
+It introduces more types and more schemas, and they have only niche use-cases.
 
 It is also inelegant in that we hash a bunch of information into the extended message (by hashing the `TxPrefix`),
-and then we hash it again via the `TxSummary`, because the `TxSummary` contains some of this information duplicated.
+and then we hash it again via the `TxSummary`. The `TxSummary` contains much of the same information as the `TxPrefix`.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 Although doing this increases the complexity of transaction validation, not doing it considerably increases
-the complexity of hardware wallet implementation and could delay the ship date of hardware wallet support.
+the complexity of hardware wallet implementation and could delay the ship date of practical hardware wallet support.
 
 Although it is inelegant to hash a bunch of stuff a second time, in practical terms, the cost of doing this is very low.
 
@@ -178,14 +185,8 @@ is actually shipped.
 It may be that hardware wallets will initially cut scope and not seek to support that feature. Then, they could cut the `InputRules`
 from the `TxInSummary` and they could assume that `address` is mandatory in `TxOutSummary::address`.
 
-They might also seek to compress or remove redundancy in some of these structures. Strictly speaking, the `TxSummaryUnblindingData`
-has no connection to MobileCoin protocol rules, it's rather a detail of the hardware wallets, so it is not necessary to create an
-MCIP for this.
-
 We view it as the prerogative of hardware wallets to define their own wire format as they see fit and carry out whatever compression / improvements they
-think are appropriate. It seems worthwhile to define a "proof of concept" `TxSummaryUnblindingData` object and show how it can be validated
-against a `TxSummary` to provide at least a baseline or starting point for such projects, since if there is actually a defect in the
-design that prevents `TxSummary` from being unblinded effectively, it would defeat the purpose of this improvement proposal.
+think are appropriate. The `TxSummaryUnblindingData` schema is only meant as a proof of concept and a starting point for such projects.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -254,7 +254,7 @@ For outputs, we can use the following decision tree:
 * In the final case, the `TxOutUnblindingData` doesn't contain an address or `tx_private_key`. This can occur normally when the `TxOut`
   was not created using `TransactionBuilder.add_output` interface, but rather
   came as a required (or partial fill) output from a Signed Contingent Input which was added to the `Tx`.
-  In this case it is not addressed to ourself, and due to the anonyminity properties of the MCIP 31 atomic swaps, we cannot know who
+  In this case it is not addressed to ourself, and due to the anonymity properties of the MCIP 31 atomic swaps, we cannot know who
   it is actually addressed to. We can only know that it goes to our anonymous swap counterparty.
   However, it's not okay to say that addresses / tx_private keys are optional for things that don't match to ourselves, because this
   allows the (adversarial) host computer to simply omit the address when they don't want to tell the hardware wallet where a payment is going.

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -346,7 +346,7 @@ compute a proper merlin digest of the entire `Tx` object, which would also make 
 
 ## SCI support, definition of `TxSummaryUnblindingData`
 
-We have tried to future-proof this design against [MCIP 31](https://github.com/mobilecoinfoundation/mcips/pull/31) Signed Contingent Inputs being present in the `Tx`.
+We have tried to future-proof this design against [MCIP 31](0031-transactions-with-contingent-inputs.md) Signed Contingent Inputs being present in the `Tx`.
 However, these cannot even be used until block version 3, and may not be in common use at the time that hardware wallet support
 is actually shipped.
 

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -306,7 +306,7 @@ The following analysis explains why these attempts fail:
   digest is signed, then the transaction will fail validation.
 
 There is an additional possibility: Suppose that the hardware wallet has features that also support signing the MCIP 31 SCIs. Then it could be possible
-that we authorize an sign an SCI, and then later we build a transaction that matches against it, so that we are essentially "trading with ourselves".
+that we authorize and sign an SCI, and then later we build a transaction that matches against it, so that we are essentially "trading with ourselves".
 In this scenario, a device using the above decision tree would (accurately) identify `TxOut`'s as going to ourselves, but identify the SCI input as
 coming from an "anonymous swap counterparty".
 

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -126,11 +126,9 @@ In mainnet at time of writing, with about 1 million blocks in the ledger, this w
 
 In the proof-of-concept work for this proposal, we measured exactly the size on the wire of a max-size and min-size Tx's with 32 element merkle proofs: 
 
--------------------------------------------------------------------------------------------------------
 |                               | Min-size (1 input, 1 output) Tx | Max-size (16 input, 16 output) Tx |
 |-------------------------------|---------------------------------|-----------------------------------|
 | Proto-encoded tx size (bytes) | 20_020                          | 309_238                           |
--------------------------------------------------------------------------------------------------------
 
 Note that this still does not give the device enough to actually compute the data in the `TxSummaryUnblindingReport`,
 it would still need at least the data in the `TxSummaryUnblindingData` to see the amounts and entities associated to
@@ -145,13 +143,11 @@ To verify this digest, the amounts and destinations of the outputs, and the amou
 * The `TxSummary` (piecewise)
 * The `TxSummaryUnblindingData` (piecewise)
 
---------------------------------------------------------------------------------------------------------------
 |                                      | Min-size (1 input, 1 output) Tx | Max-size (16 input, 16 output) Tx |
 |--------------------------------------|---------------------------------|-----------------------------------|
 | Proto-encoded TxSummary size (bytes) | 176                             | 2_726                             |
 | " TxSummaryUnblindingData (bytes)    | 295                             | 4_690                             |
 | Total (+ 32)                         | 503                             | 7_416                             |
---------------------------------------------------------------------------------------------------------------
 
 The size on the stack of the `TxSummaryStreamingVerifier` (using `heapless`) is 1_302 bytes.
 
@@ -163,14 +159,12 @@ The `TxSummaryStreamingVerifier` has four steps in its protocol:
 
 The sizes of the payloads which must be transferred to make each step (in the POC) are:
 
---------------------------------------------------------------------------
 |                                      | Wire size (proto-encoded bytes) |
 |--------------------------------------|---------------------------------|
 | Initialization                       | 32 + 32 + 4 + 2 * 8 = 84        |
 | Digest output                        | 129 + 243 = 372                 |
 | Digest input                         | 36  + 45  = 81                  |
 | Finalization                         | 3 * (2 + 8) = 30                |
---------------------------------------------------------------------------
 
 The largest value in the above is the Digest output step, and the bulk of this is coming
 from the need to send a `PublicAddress` in order to verify that a `TxOut` was

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -1,6 +1,6 @@
 - Feature Name: tx_summary_digest
 - Start Date: 2022-10-08
-- MCIP PR: [mobilecoinfoundation/mcips#0050](https://github.com/mobilecoinfoundation/mcips/pull/0050)
+- MCIP PR: [mobilecoinfoundation/mcips#0052](https://github.com/mobilecoinfoundation/mcips/pull/0052)
 - Tracking Issue: [mobilecoinfoundation/mobilecoin#2686](https://github.com/mobilecoinfoundation/mobilecoin/issues/2686)
 
 # Summary

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -178,11 +178,14 @@ TxOutSummary: CompressedRistrettoPublic target_key
 TxOutSummary: MaskedAmount masked_amount
 TxOutSummary: bool associated_to_input_rules
 TxInSummary: CompressedCommitment pseudo_output_commitment
-TxInSummary: bool has_input_rules
+TxInSummary: bytes input_rules_digest
 ```
 
 A hardware wallet which is asked to sign an MLSAG can expect to see that 32 byte digest
 and the `TxSummary`.
+
+The `TxInSummary::input_rules_digest` is a canonical 32-byte digest of the `InputRules` object in the `TxIn`
+if any exists. Otherwise it is 0 bytes.
 
 ## Security
 [security]: #security
@@ -439,11 +442,11 @@ To verify this digest, the amounts and destinations of the outputs, and the amou
 * The `TxSummary` (piecewise)
 * The `TxSummaryUnblindingData` (piecewise)
 
-|                                      | Min-size (1 input, 1 output) Tx | Max-size (16 input, 16 output) Tx |
-|--------------------------------------|---------------------------------|-----------------------------------|
-| Proto-encoded TxSummary size (bytes) | 176                             | 2_726                             |
-| " TxSummaryUnblindingData (bytes)    | 295                             | 4_690                             |
-| Total (+ 32)                         | 503                             | 7_416                             |
+|                                                  | Min-size (1 input, 1 output) Tx | Max-size (16 input, 16 output) Tx |
+|--------------------------------------------------|---------------------------------|-----------------------------------|
+| Proto-encoded TxSummary size (bytes)             | 176                             | 2_726                             |
+| Proto-encoded TxSummaryUnblindingData (bytes)    | 295                             | 4_690                             |
+| Total (+ 32)                                     | 503                             | 7_416                             |
 
 The size on the stack of the proof-of-concept `TxSummaryStreamingVerifier` (using `heapless`) is 1_600 bytes.
 
@@ -459,7 +462,7 @@ The sizes of the payloads which must be transferred to make each step (in the PO
 |--------------------------------------|---------------------------------|
 | Initialization                       | 32 + 32 + 4 + 2 * 8 = 84        |
 | Digest output                        | 129 + 243 = 372                 |
-| Digest input                         | 36  + 45  = 81                  |
+| Digest input                         | 78  + 45  = 123                 |
 | Finalization                         | 3 * (2 + 8) = 30                |
 
 The largest value in the above is the Digest output step, and the bulk of this is coming

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -87,12 +87,12 @@ In block version 0, the Ring MLSAG's sign the "extended message" computed roughl
 
 ```mermaid
 graph TB
-A[TxPrefix] -->|merlin| B[message]
+A[TxPrefix] -->|merlin| B[[message -32 bytes-]]
 B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
 M[concatenation] --> N
-N[[extended_message -many bytes-]]
+N[extended_message -many bytes-]
 ```
 
 In block version 2, we changed this (in [MCIP 25](https://github.com/mobilecoinfoundation/mcips/pull/25)) so that the Ring MLSAG's sign the
@@ -100,7 +100,7 @@ In block version 2, we changed this (in [MCIP 25](https://github.com/mobilecoinf
 
 ```mermaid
 graph TB
-A[TxPrefix] -->|merlin| B[message]
+A[TxPrefix] -->|merlin| B[[message -32 bytes-]]
 B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
@@ -114,7 +114,7 @@ which is computed roughly as follows:
 
 ```mermaid
 graph TB
-A[TxPrefix] -->|merlin| B[message]
+A[TxPrefix] -->|merlin| B[[message -32 bytes-]]
 B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -226,7 +226,7 @@ M[merlin] --> N
 N[[extended_message_digest -32 bytes-]]
 ```
 
-We propose that in block version 3, Ring MLSAGs (other than the [MCIP 31](https://github.com/mobilecoinfoundation/mcips/pull/31) Signed Contingent Inputs)
+We propose that in block version 3, Ring MLSAGs (other than the [MCIP 31](0031-transactions-with-contingent-inputs.md) Signed Contingent Inputs)
 should now sign the `extended_message_and_tx_summary_digest`,
 which is computed roughly as follows:
 

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -91,7 +91,8 @@ A[TxPrefix] -->|merlin| B[message]
 B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
-M[concatenation] --> N[extended message (many bytes)]
+M[concatenation] --> N
+N[extended message (many bytes)]
 ```
 
 In block version 2, we changed this (in [MCIP 25](https://github.com/mobilecoinfoundation/mcips/pull/25)) so that the Ring MLSAG's sign the
@@ -103,7 +104,8 @@ A[TxPrefix] -->|merlin| B[message]
 B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
-M[merlin] --> N[extended message digest (32 bytes)]
+M[merlin] --> N
+N[extended message digest (32 bytes)]
 ```
 
 In the current proposal, we propose that in block version 3 they should sign the following digest:
@@ -114,8 +116,8 @@ A[TxPrefix] -->|merlin| B[message]
 B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
-M[merlin] --> N[extended message digest (32 bytes)]
-N --> P
+M[merlin] --> N
+N[extended message digest (32 bytes)] --> P
 O[TxSummary] --> P
 P[merlin] --> Q[extended message and tx summary digest (32 bytes)]
 ```

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -190,6 +190,8 @@ and about 40s to stream a max-size `Tx`.
 It suggests that it should take <.25s to stream all of the data required by the `TxSummaryStreamingVerifier`,
 even for a max-size `Tx`.
 
+(Note that this is extrapolating from anecdotes and may be wildly off.)
+
 90% of the impact of this change comes from making it so that we don't have to stream merkle proofs to the hardware device.
 The hardware device does not care about these merkle proofs anyways, and isn't capable of checking them.
 

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -199,6 +199,12 @@ this way, but the attacker will not be able to get consensus to accept those sig
 knows that either the `TxSummary` is accurate, or it's signature doesn't matter because the `Tx` will not
 be accepted.
 
+**Note**: One concern here is that, we do not want to create a "signing oracle" whereby the host computer
+can trick the hardware wallet into signing something that has a meaning that they never intended. It's important
+here that the host computer gives the device an extended message digest, followed by the `TxSummary`, and the
+device computes a (domain separated) Merlin digest based on this. If there is a second, alternate meaning to
+this digest, it means that the attacker found a collision in Merlin.
+
 A hardware wallet can also expect to be supplied with the `TxSummaryUnblindingData` which allows it to see
 as much information as possible about where funds are coming from and where they are going in the `Tx`.
 
@@ -275,9 +281,10 @@ For inputs, we can use the following decision tree:
   the hardware device knows that the computer has lied / provided a false unmasking, but there is no legitimate reason
   for the computer to fail to do this, because regardless of whether this is our own input or a signed input from a
   counterparty, we can expect to have the unmasked amount or there is no way we can possibly spend it.
-* Now having the amount in hand, the next step is to check the `has_input_rules` flag from `TxInSummary`. We know that
-  this flag is accurate because the consensus enclave checks the `TxSummary` and can see which inputs actually have rules.
-  If there are no rules, then we know that we must be signing for this transaction. If there are rules then we attribute
+* Now having the amount in hand, the next step is to check if `input_rules_digest` is nonempty in `TxInSummary`. We know that
+  this is nonempty exactly when there are rules, because the consensus enclave checks the `TxSummary` and can see which
+  inputs actually have rules, and generates a digest of those rules exactly when they are present.
+  If there are no rules, then we know that we must be signing for this input. If there are rules then we attribute
   the input to an anonymous swap counterparty.
 
 #### Assumptions around `InputRules`

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -164,7 +164,8 @@ TxInSummary: Option~InputRules~ input_rules
 A hardware wallet which is asked to sign an MLSAG can expect to see that 32 byte digest
 and the `TxSummary`.
 
-**Security**:
+# Security
+[security]: #security
 From a security point of view, the hardware wallet can know that it is intractable
 for someone to find a different `TxSummary` that produces the same `extended_message_and_tx_summary` digest,
 so if it signs the MLSAG, this is the only thing that it can be committing to.

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -35,8 +35,8 @@ Then, there is a Merkle proof for each `TxIn` (at most 16) and each mixin (11 pe
 
 Having to transfer this much data to a tiny device will slow down the user experience
 noticeably, and will greatly increase the complexity of implementation, because the device
-has much less memory than this and would have to use some kind of "windowing" strategy
-to compute the hash.
+has much less memory than this and would have to incrementally stream chunks of data
+to the hardware device to compute the hash.
 
 On the other hand, if the digest that the Ring MLSAGs sign is changed as proposed, then
 we only need to send 32 bytes followed by the `TxSummary` to prove to the device where

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -92,7 +92,7 @@ B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
 M[concatenation] --> N
-N[extended message (many bytes)]
+N[[extended message (many bytes)]]
 ```
 
 In block version 2, we changed this (in [MCIP 25](https://github.com/mobilecoinfoundation/mcips/pull/25)) so that the Ring MLSAG's sign the
@@ -105,7 +105,7 @@ B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
 M[merlin] --> N
-N[extended message digest (32 bytes)]
+N[[extended message digest (32 bytes)]]
 ```
 
 In the current proposal, we propose that in block version 3 they should sign the following digest:
@@ -117,9 +117,10 @@ B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
 M[merlin] --> N
-N[extended message digest (32 bytes)] --> P
+N[[extended message digest (32 bytes)]] --> P
 O[TxSummary] --> P
-P[merlin] --> Q[extended message and tx summary digest (32 bytes)]
+P[merlin] --> Q
+Q[[extended message and tx summary digest (32 bytes)]]
 ```
 
 The `TxSummary` is a new object with the following schema, which is constructed

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -359,10 +359,15 @@ For outputs, we can use the following decision tree:
   
 
 **Note**: There is an assumption which is worth explaining here, that outputs that match to `InputRules` never belong to a person signing the transaction.
-This is reasonable because it is never sensible for a person to be a counterparty to their own Signed Contingent Input. `InputRules` can only be used
+This is reasonable because it is never sensible for a person to be a counterparty to their own Signed Contingent Input. Conceptually, an SCI is a signed input
+with "strings attached", and the `InputRules` are those strings. So the nature of the interaction is "here is my input which you can use, as long as you
+follow these rules". `InputRules` can only be used
 to constrain the person who uses a particular signed input in a transaction. If you are in fact the signer of the input, you could always remove the input
-rules and sign the input normally, and your transaction would be valid if it were valid before (in strictly more cases). A real client would always prefer
-not to make their own input into an SCI, for simplicity. This observation applies no matter what future kinds of `InputRules` we create -- if you are capable
+rules and sign the input normally, and your transaction would be valid if it were valid before (in strictly more cases). Offering yourself one of your own
+inputs "with strings attached" never makes sense, because you already had the input and could just sign it again without the strings.
+
+A real client would always prefer not to make their own input into an SCI, for simplicity.
+This observation applies no matter what future kinds of `InputRules` we create -- if you are capable
 of signing for a given input on your own, you can always bypass any `InputRules` on an SCI by just signing that input, not as an SCI.
 Regardless, in the above decision tree, we test if a `TxOut` belongs to the signer using view-key
 matching before reaching the last case and checking the `associated_to_input_rules` flag. So if we do actually own an input, we will identify it thusly, even

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -80,10 +80,15 @@ to change the way that the digest which `RingMLSAG`'s sign is computed.
 **Note**: This change does not impact the digest that [MCIP 31](0031-transactions-with-contingent-inputs.md) signed contingent inputs (SCIs) sign,
 those inputs sign the same digest that was specified in MCIP 31.
 
-During transaction construction, the signer computes the extended message digest as before,
-but now creates a merlin transcript using that 32-byte digest, followed by digesting the
-`TxSummary`. The MLSAG's (except for SCIs) will sign 32-bytes extracted from this digest.
-The verifier similarly computes this
+During transaction construction, the signer:
+1. Computes the `extended-message-digest` as before
+1. Creates a merlin transcript, appending that digest (using the `mc-crypto-digestible-scheme`)
+1. Appends `TxSummary` (using the `mc-crypto-digestible` scheme)
+1. Extracts 32 bytes from this digest, the `extended-message-and-tx-summary-digest`.
+
+The MLSAG's (except for SCIs) will now sign this digest (instead of the `extended-message-digest` as previously).
+
+The transaction verifier similarly computes this
 `extended-message-and-tx-summary digest` and verifies that the MLSAGs sign this.
 
 **Note**: This means that the `TxSummary` needs to be constructible by the consensus enclave, given only

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -62,7 +62,7 @@ The purpose of a `TxSummary` is that:
     * The signer themselves
     * A known contact, identified by their public address
     * An anonymous swap counterparty
-  * For each input, the amount, and the entity from whcih it came, which is one of two possibilities:
+  * For each input, the amount, and the entity from which it came, which is one of two possibilities:
     * The signer themselves
     * An anonymous swap counterparty
 

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -98,7 +98,7 @@ is responsible to compute this when it creates
 a `Tx`, and then it can be streamed to, and verified by, the hardware device which is asked to sign.
 
 When a hardware wallet is asked to sign an MLSAG, we can give it now the `extended_message_digest`
-and steam it the `TxSummary` and the `TxSummaryUnblindingData`, and it can compute the appropriate digest from this for the MLSAG to sign.
+and stream it the `TxSummary` and the `TxSummaryUnblindingData`, and it can compute the appropriate digest from this for the MLSAG to sign.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -322,7 +322,7 @@ Recall that we must consider the following cases and successfully obtain the des
   * An anonymous swap counterparty
 
 For outputs, we can use the following decision tree:
-* Given a `TxOutSummary`, we have the public key, target key, and masked amount of the TxOut
+* Given a `TxOutSummary`, we have the public key, target key, and masked amount of the TxOut.
   On the hardware device, we have the account view private key of the signer. We can attempt to view-key match the TxOut,
   performing key-exchange against the public key, obtaining the `TxOut` shared secret. This can be tested against the
   `MaskedAmount` and yields an unblinded amount if it works. This amount is correct -- it is discrete-log hard to find
@@ -336,10 +336,10 @@ For outputs, we can use the following decision tree:
   the call to `TxOut::new` enough to reproduce the `TxOut` public key, the `TxOut` target key, and the `TxOut` masked amount.
   If all of these are a match for the `TxOutSummary`, then the device has established that the `TxOut` was originally addressed to
   this person with this amount -- it is discrete-log hard to find another amount with the same commitment. It is also generally
-  impossible to make an account that belongs to two addresses -- starting from two addresses with different view public keys,
+  impossible to make a TxOut that belongs to two addresses -- starting from two addresses with different view public keys,
   finding two different tx_private keys that produce the same tx out public key implies knowledge of a linear relation between
   the view private keys. Also obtaining a collision of tx target keys requires finding a hash collision which has negligible success
-  probability.
+  probability. (TODO maybe more detail on this? I think it's a pretty fundamental security property of mobilecoin though.)
 * The final case occurs when the `TxOut` was not addressed to ourselves or created using `TransactionBuilder.add_output`, but rather
   came as a required (or partial fill) output from a Signed Contingent Input. In this case it is not addressed to ourself, and due
   to the anonyminity properties of the MCIP 31 atomic swaps, we cannot know who it is actually addressed to. We can only know that

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -92,7 +92,7 @@ B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
 M[concatenation] --> N
-N[[extended message (many bytes)]]
+N[[extended_message -many bytes-]]
 ```
 
 In block version 2, we changed this (in [MCIP 25](https://github.com/mobilecoinfoundation/mcips/pull/25)) so that the Ring MLSAG's sign the
@@ -105,7 +105,7 @@ B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
 M[merlin] --> N
-N[[extended message digest (32 bytes)]]
+N[[extended_message_digest -32 bytes-]]
 ```
 
 In the current proposal, we propose that in block version 3 they should sign the following digest:
@@ -117,10 +117,10 @@ B --> M
 C[pseudo_output_commitments] --> M
 D[range_proofs] --> M
 M[merlin] --> N
-N[[extended message digest (32 bytes)]] --> P
+N[[extended_message_digest -32 bytes-]] --> P
 O[TxSummary] --> P
 P[merlin] --> Q
-Q[[extended message and tx summary digest (32 bytes)]]
+Q[[extended_message_and_tx_summary_digest -32 bytes-]]
 ```
 
 The `TxSummary` is a new object with the following schema, which is constructed

--- a/text/0052-tx-summary-digest.md
+++ b/text/0052-tx-summary-digest.md
@@ -39,8 +39,8 @@ has much less memory than this and would have to incrementally stream chunks of 
 to the hardware device to compute the hash.
 
 On the other hand, if the digest that the Ring MLSAGs sign is changed as proposed, then
-we only need to send 32 bytes followed by the `TxSummary` to prove to the device where
-the digest that the MLSAG's are signing comes from, and so what the outcome of the `Tx` is.
+we only need to send 32 bytes followed by the `TxSummary`. This will be enough to prove 
+to the device what the outcome of the `Tx` is.
 So we can avoid sending all Merkle proofs, bulletproofs, encrypted fog hints, memos, etc.
 and reduce the traffic with the device by perhaps a factor of 10 or so in the worst case,
 as well as reducing the implementation complexity.


### PR DESCRIPTION
A proposal to introduce a `TxSummary` object and incorporate it into the digest which MLSAG's sign, to help hardware wallets.

[Rendered Proposal](https://github.com/garbageslam/mcips/blob/tx_summary_digest/text/0052-tx-summary-digest.md)